### PR TITLE
fix(web): drop BETTER_AUTH_URL and __BASE_URL__ in favor of VITE_BASE_URL

### DIFF
--- a/apps/web/src/components/settings/project/edit-slug.tsx
+++ b/apps/web/src/components/settings/project/edit-slug.tsx
@@ -12,6 +12,7 @@ import {
   SettingsCardHeader,
   SettingsCardTitle,
 } from "@/components/settings/card";
+import { env } from "@/env";
 import { authClient } from "@/lib/auth-client";
 import { safeString } from "@/lib/projects/schemas";
 import { queries } from "@/lib/queries";
@@ -76,8 +77,7 @@ export function ProjectEditSlug() {
     return null;
   }
 
-  // biome-ignore lint/correctness/noUndeclaredVariables: this is a vite constant
-  const rawBaseUrl = __BASE_URL__;
+  const rawBaseUrl = env.VITE_BASE_URL;
   const appURL = new URL(rawBaseUrl);
   let baseUrl = new URL(rawBaseUrl).hostname;
 

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -5,7 +5,6 @@ export const env = createEnv({
   server: {
     PORT: z.coerce.number().int().positive().optional(),
     HOST: z.string().optional(),
-    BETTER_AUTH_URL: z.string().min(1),
     BETTER_AUTH_SECRETS: z.string().min(1),
     DATABASE_URL: z.string().min(1),
     REDIS_URL: z.string().min(1),
@@ -33,6 +32,7 @@ export const env = createEnv({
   },
   clientPrefix: "VITE_",
   client: {
+    VITE_BASE_URL: z.string().min(1),
     VITE_DEBUG: z
       .enum(["true", "false"])
       .optional()
@@ -42,7 +42,6 @@ export const env = createEnv({
   runtimeEnv: {
     PORT: process.env.PORT,
     HOST: process.env.HOST,
-    BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
     BETTER_AUTH_SECRETS: process.env.BETTER_AUTH_SECRETS,
     DATABASE_URL: process.env.DATABASE_URL,
     REDIS_URL: process.env.REDIS_URL,
@@ -60,6 +59,7 @@ export const env = createEnv({
     CF_ZONE_ID: process.env.CF_ZONE_ID,
     TEMPLATING_BUILDER_URL: process.env.TEMPLATING_BUILDER_URL,
     TEMPLATING_BUILDER_SECRET: process.env.TEMPLATING_BUILDER_SECRET,
+    VITE_BASE_URL: import.meta.env.VITE_BASE_URL,
     VITE_DEBUG: import.meta.env.VITE_DEBUG,
   },
   emptyStringAsUndefined: true,

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,6 +1,6 @@
 import { createAuthClient } from "@repo/persistence/auth/client";
+import { env } from "@/env";
 
 export const authClient = createAuthClient({
-  // biome-ignore lint/correctness/noUndeclaredVariables: this is a vite constant
-  baseURL: __BASE_URL__,
+  baseURL: env.VITE_BASE_URL,
 });

--- a/apps/web/src/lib/auth.server.ts
+++ b/apps/web/src/lib/auth.server.ts
@@ -45,6 +45,7 @@ const stripeConfig =
     : undefined;
 
 export const auth = createAuth({
+  baseUrl: env.VITE_BASE_URL,
   db,
   redis,
   socialProviders:

--- a/apps/web/src/routes/auth/sign-in.tsx
+++ b/apps/web/src/routes/auth/sign-in.tsx
@@ -6,6 +6,7 @@ import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { z } from "zod";
+import { env } from "@/env";
 import { type SignInBody, signInBodySchema } from "@/lib/auth/schemas";
 import { authClient } from "@/lib/auth-client";
 
@@ -24,8 +25,7 @@ function RouteComponent() {
   const { isGitHubAuthEnabled } = Route.useRouteContext();
   const lastMethod = authClient.getLastUsedLoginMethod();
 
-  // biome-ignore lint/correctness/noUndeclaredVariables: this is a vite constant
-  const baseURL = __BASE_URL__;
+  const baseURL = env.VITE_BASE_URL;
   const callbackURL = redirect
     ? `${baseURL}${redirect.startsWith("/") ? redirect : `/${redirect}`}`
     : `${baseURL}/`;

--- a/apps/web/src/routes/auth/sign-up.tsx
+++ b/apps/web/src/routes/auth/sign-up.tsx
@@ -6,6 +6,7 @@ import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { z } from "zod";
+import { env } from "@/env";
 import { type SignUpBody, signUpBodySchema } from "@/lib/auth/schemas";
 import { authClient } from "@/lib/auth-client";
 
@@ -24,8 +25,7 @@ function RouteComponent() {
   const { isGitHubAuthEnabled } = Route.useRouteContext();
   const lastMethod = authClient.getLastUsedLoginMethod();
 
-  // biome-ignore lint/correctness/noUndeclaredVariables: this is a vite constant
-  const baseURL = __BASE_URL__;
+  const baseURL = env.VITE_BASE_URL;
   const callbackURL = redirect
     ? `${baseURL}${redirect.startsWith("/") ? redirect : `/${redirect}`}`
     : `${baseURL}/`;

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-declare const __BASE_URL__: string;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -9,10 +9,6 @@ import { defineConfig } from "vite";
 import { resolveUseSyncExternalStoreFromReact } from "./vite/resolve-use-sync-external-store-from-react.ts";
 
 const config = defineConfig({
-  define: {
-    // Public URL only — Docker bakes BAKED_VITE_BASE_URL; entrypoint rewrites at start.
-    __BASE_URL__: JSON.stringify(process.env.VITE_BASE_URL ?? ""),
-  },
   server: {
     // Portless sets HOST=127.0.0.1 so the proxy can reach Vite over IPv4.
     host: process.env.HOST,

--- a/turbo.json
+++ b/turbo.json
@@ -10,14 +10,13 @@
         "VITE_API_URL",
         "VITE_BASE_URL",
         "VITE_EDITION",
-        "BETTER_AUTH_URL",
         "APP_URL"
       ]
     },
     "@repo/api#build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "env": ["NODE_ENV", "BETTER_AUTH_URL", "APP_URL"],
+      "env": ["NODE_ENV", "APP_URL"],
       "outputs": ["build/**"]
     },
     "@repo/web#build": {


### PR DESCRIPTION
## What's Changed

Web had three names for the same public origin: `BETTER_AUTH_URL` (server env), Vite `define` `__BASE_URL__`, and the Docker-baked `VITE_BASE_URL`. They are now one variable.

- `VITE_BASE_URL` is a required client env on `apps/web/src/env.ts`
- Auth client, GitHub OAuth callbacks, and project slug UI read `env.VITE_BASE_URL`
- Better Auth is created with `baseUrl: env.VITE_BASE_URL` so it no longer looks for `BETTER_AUTH_URL`
- Vite `define` / `__BASE_URL__` and `vite-env.d.ts` are gone
- `BETTER_AUTH_URL` removed from web env and turbo cache keys

Docker is unchanged: bake `BAKED_VITE_BASE_URL`, rewrite at container start via the existing entrypoint.

## Type of Change

- [ ] 🚀 New feature (feat)
- [x] 🐛 Bug fix (fix)
- [x] ♻️ Refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] 📚 Documentation (docs)
- [ ] 🧪 Tests (test)
- [x] 🔧 Build/CI (build/ci)
- [ ] 💄 Style changes (style)
- [ ] 🏗️ Chore (chore)

## Impact & Compliance

- [x] 🔐 Security impact assessed (auth, tokens, scopes, PII)
- [ ] 🗃️ Database migration included with rollback/backfill notes
- [x] 📄 Docs/README/CHANGELOG updated or N/A

Public origin is still the web URL. Secrets (`BETTER_AUTH_SECRETS`) are unchanged. No migration.

## Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added tests for new functionality (if applicable)

## Test plan

- [ ] Local web `.env` has `VITE_BASE_URL` (not `BETTER_AUTH_URL`); sign-in / GitHub callback / cookies still work
- [ ] Project slug settings still show the correct host
- [ ] Docker/Railway: set `VITE_BASE_URL` at deploy; image still bakes the placeholder and the entrypoint rewrites it

## Breaking Changes

- [x] This PR introduces breaking changes
- [ ] This PR is backwards compatible

**Web env:** stop setting `BETTER_AUTH_URL`. Set `VITE_BASE_URL` to the public web origin (same value you used for `BETTER_AUTH_URL`). `BETTER_AUTH_SECRETS` is still required.

---

**Alpha Release Note**: This project is in alpha. Breaking changes are expected and will be documented in releases.