### PR TITLE
fix(web): load organizations through server functions in beforeLoad

### DIFF
--- a/apps/web/src/lib/auth.functions.ts
+++ b/apps/web/src/lib/auth.functions.ts
@@ -1,6 +1,7 @@
 import { ROLES } from "@repo/persistence/auth/constants";
 import { createMiddleware, createServerFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
+import { z } from "zod";
 import { auth } from "@/lib/auth.server";
 
 const readSession = async () => {
@@ -31,4 +32,41 @@ export const adminMiddleware = createMiddleware({ type: "function" })
       throw new Error("Unauthorized");
     }
     return next();
+  });
+
+export const listOrganizations = createServerFn({ method: "GET" })
+  .middleware([sessionMiddleware])
+  .handler(async () => {
+    const headers = getRequestHeaders();
+    return await auth.api.listOrganizations({ headers });
+  });
+
+export const getFullOrganization = createServerFn({ method: "GET" })
+  .middleware([sessionMiddleware])
+  .validator(z.object({ organizationSlug: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    const headers = getRequestHeaders();
+    try {
+      return await auth.api.getFullOrganization({
+        headers,
+        query: { organizationSlug: data.organizationSlug },
+      });
+    } catch (error) {
+      const statusCode =
+        error instanceof Error &&
+        "statusCode" in error &&
+        typeof error.statusCode === "number"
+          ? error.statusCode
+          : undefined;
+
+      switch (statusCode) {
+        case 400:
+        case 401:
+        case 403:
+        case 404:
+          return null;
+        default:
+          throw error;
+      }
+    }
   });

--- a/apps/web/src/lib/queries/organizations.ts
+++ b/apps/web/src/lib/queries/organizations.ts
@@ -1,5 +1,5 @@
 import * as q from "@ted-too/query-key-factory/query";
-import { authClient } from "@/lib/auth-client";
+import { getFullOrganization, listOrganizations } from "@/lib/auth.functions";
 import {
   listCustomDomainsFn,
   listProjectProvidersFn,
@@ -15,33 +15,20 @@ import {
 
 export const organizations = q.createQueryKeys("organizations", {
   list: q.static({
-    queryFn: async ({ signal }) => {
-      const { data, error } = await authClient.organization.list({
-        fetchOptions: { signal },
-      });
-
-      if (error) {
-        return Promise.reject(error);
-      }
-
-      return data;
-    },
+    queryFn: async () => await listOrganizations(),
   }),
   bySlug: q.dynamic((slug: string) => ({
     queryKey: [slug],
-    queryFn: async ({ signal }) => {
-      const { data, error } = await authClient.organization.getFullOrganization(
-        {
-          query: { organizationSlug: slug },
-          fetchOptions: { signal },
-        }
-      );
+    queryFn: async () => {
+      const organization = await getFullOrganization({
+        data: { organizationSlug: slug },
+      });
 
-      if (error) {
-        return Promise.reject(error);
+      if (!organization) {
+        return Promise.reject(new Error("No organization found"));
       }
 
-      return data;
+      return organization;
     },
     listApiKeys: q.static({
       queryFn: async () => await listApiKeysFn({ data: { orgSlug: slug } }),

--- a/apps/web/src/routes/_authd/$orgSlug.tsx
+++ b/apps/web/src/routes/_authd/$orgSlug.tsx
@@ -24,13 +24,17 @@ import {
   type NavItemGroup,
   type RequiredPermissions,
 } from "@/components/layout/app-sidebar";
+import { listOrganizations } from "@/lib/auth.functions";
 import { authClient } from "@/lib/auth-client";
 import { queries } from "@/lib/queries";
 
 export const Route = createFileRoute("/_authd/$orgSlug")({
   beforeLoad: async ({ context, params }) => {
-    const userOrganizations = await context.queryClient.ensureQueryData(
-      queries.organizations.list
+    const userOrganizations = await listOrganizations();
+
+    await context.queryClient.setQueryData(
+      queries.organizations.list.queryKey,
+      userOrganizations
     );
 
     const currentOrganization = userOrganizations.find(

--- a/apps/web/src/routes/_authd/index.tsx
+++ b/apps/web/src/routes/_authd/index.tsx
@@ -4,12 +4,16 @@ import { useSuspenseQueries } from "@tanstack/react-query";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { OrganizationLogo } from "@/components/layout/nav-projects";
 import { NavUser } from "@/components/layout/nav-user";
+import { listOrganizations } from "@/lib/auth.functions";
 import { queries } from "@/lib/queries";
 
 export const Route = createFileRoute("/_authd/")({
   beforeLoad: async ({ context }) => {
-    const organizations = await context.queryClient.ensureQueryData(
-      queries.organizations.list
+    const organizations = await listOrganizations();
+
+    await context.queryClient.setQueryData(
+      queries.organizations.list.queryKey,
+      organizations
     );
 
     if (organizations.length === 0) {


### PR DESCRIPTION
## Summary
- Auth-related org reads in `beforeLoad` no longer use the client SDK, which cannot see request cookies during SSR.
- `listOrganizations` and `getFullOrganization` are server functions (with session middleware) that call `auth.api` with request headers, matching `getSession`.
- Missing/unauthorized full-org fetches return `null` instead of bubbling Better Auth 401s as 500s.

## Test plan
- [ ] Signed-in visit to `/` redirects to an existing project (or `/create-project` if none)
- [ ] Signed-in visit to `/$orgSlug` for a project you belong to loads the app shell
- [ ] Signed-in visit to an unknown/other-user slug redirects to `/` without a 500
- [ ] Signed-out visit still redirects to `/auth/sign-in`
- [ ] Hard refresh on a project route still has the session and org list (no client-auth cookie miss)